### PR TITLE
Fix: Rounding of child epoch length

### DIFF
--- a/src/lib/form-schema.ts
+++ b/src/lib/form-schema.ts
@@ -232,7 +232,7 @@ export const formSchema = z
                 BigNumber(data.pinningChainEpochLength)
                     .multipliedBy(pinningChain.blockTime)
                     .dividedBy(data.childBlockTime)
-                    .toString()
+                    .toFixed(0)
             ), // TODO take next higher number for non absolute result?
             contractSourcesPrefix: pinningChain.contractSourcesPrefix,
             enablePinning: true,


### PR DESCRIPTION
Rounding did not work correctly, producing an error. Here comes the fix.